### PR TITLE
[Automated PR] Update chart version in lab to 1.0.6

### DIFF
--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -2,7 +2,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.5",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/lab:1.0.6",
       "created_on": "2021-02-19T21:34:37.815Z",
       "description": "",
       "gpu_enabled": true,


### PR DESCRIPTION
This PR updates the `chart` field in `fixtures.json` to use the new version: `1.0.6`.
Please review and merge if everything looks good.