### PR TITLE
[Automated PR] Update chart version in rstudio to 1.0.6

### DIFF
--- a/fixtures/apps_fixtures.json
+++ b/fixtures/apps_fixtures.json
@@ -233,7 +233,7 @@
   {
     "fields": {
       "category": "develop",
-      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.4",
+      "chart": "ghcr.io/scilifelabdatacentre/serve-charts/rstudio:1.0.6",
       "created_on": "2023-08-31T09:30:00.000Z",
       "description": "",
       "logo": "rstudio-logo.svg",


### PR DESCRIPTION
This PR updates the `chart` field in `fixtures.json` to use the new version: `1.0.6`.
Please review and merge if everything looks good.